### PR TITLE
Fixed the issue where 'no instances found' error was seen when show l…

### DIFF
--- a/jetapp/yang/op/rpc_get_lwaftr_statistics.py
+++ b/jetapp/yang/op/rpc_get_lwaftr_statistics.py
@@ -100,12 +100,15 @@ def snabb_statistics(output,argv):
     root = ET.fromstring(output)
     print "<snabb>"
     found = 0
+    instance_id = ""
+    for i in range(0,len(argv)):
+        if argv[i] == "id":
+            instance_id = argv[i+1]
+            break
+
     for instance in root:
-        if len(argv) != 1 :
-                if instance.findall("./id")[0].text == argv[-1]:
-                    stats_per_instance(instance)
-		    print "</snabb>"
-                    return
+        if instance_id != '' and instance.findall("./id")[0].text != argv[2]:
+            pass
         else:
 	    found += 1
             stats_per_instance(instance)


### PR DESCRIPTION
…waftr statistics | no-more was eecuted

Invalid case:
root@lwaftr1> show lwaftr statisti s id xeq | display xml
<rpc-reply xmlns:junos="http://xml.juniper.net/junos/16.1I0/junos">
    <snabb>
        <statistics>
            <id_error>
                no instance found
            </id_error>
        </statistics>
    </snabb>
    <cli>
        <banner></banner>
    </cli>
</rpc-reply>
Valid case:
root@lwaftr1> show lwaftr statisti s id xe0 | display xml
<rpc-reply xmlns:junos="http://xml.juniper.net/junos/16.1I0/junos">
    <snabb>
        <statistics>
            <id>
                xe0
            </id>
            <drop-all-ipv4-iface-bytes>
                0
            </drop-all-ipv4-iface-bytes>
            <drop-all-ipv4-iface-packets>
                0
            </drop-all-ipv4-iface-packets>
            <drop-all-ipv6-iface-bytes>
                0
            </drop-all-ipv6-iface-bytes>
            <drop-all-ipv6-iface-packets>
                0
            </drop-all-ipv6-iface-packets>
            <drop-bad-checksum-icmpv4-bytes>
                0
---(more)---
